### PR TITLE
v0.3.3 Dropped Brotli encoding, multiple organizations fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   - [Faster Loading](#faster-loading-avoiding-selenium)
   - [Proxies](#proxies)
   - [Changing model version](#changing-claude-model)
+  - [Changing Organization](#changing-organization)
 - [Troubleshooting](#troubleshooting)
 - [Donating](#donating)
 
@@ -271,6 +272,24 @@ client = ClaudeAPIClient(session, model_name="claude-2.0")
 ```
 
 You can retrieve the `model_name` strings from the [official API docs](https://docs.anthropic.com/claude/docs/models-overview#model-comparison)
+
+__________
+
+### Changing Organization
+
+As reported in issue [#23](https://github.com/st1vms/unofficial-claude-api/issues/23)
+if you're encountering 403 errors when using Selenium to auto retrieve a `SessionData` class and your account has multiple organizations,
+you may want to override the default organization retrieved.
+
+By default `get_session_data` retrieves the last organization from the result array found [here](https://claude.ai/api/organizations).
+You can override the index to fetch by using parameter `organization_index`:
+
+```py
+from claude_api.session import get_session_data
+
+# Defaults to -1 (last entry)
+session = get_session_data(organization_index=-1)
+```
 
 ## TROUBLESHOOTING
 

--- a/claude_api/client.py
+++ b/claude_api/client.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 from mimetypes import guess_type
 from zlib import decompress as zlib_decompress
 from zlib import MAX_WBITS
-from brotli import decompress as br_decompress
+#from brotli import decompress as br_decompress
 from tzlocal import get_localzone
 from requests import post as requests_post
 from curl_cffi.requests import get as http_get
@@ -468,12 +468,14 @@ class ClaudeAPIClient:
         if encoding_header == "gzip":
             # Content is gzip-encoded, decode it using zlib
             return zlib_decompress(buffer, MAX_WBITS | 16)
-        elif encoding_header == "deflate":
+        if encoding_header == "deflate":
             # Content is deflate-encoded, decode it using zlib
             return zlib_decompress(buffer, -MAX_WBITS)
-        elif encoding_header == "br":
+
+        # DROPPING BROTLI DECODING
+        #if encoding_header == "br":
             # Content is Brotli-encoded, decode it using the brotli library
-            return br_decompress(buffer)
+        #    return br_decompress(buffer)
 
         # Content is either not encoded or with a non supported encoding.
         return buffer
@@ -622,7 +624,7 @@ class ClaudeAPIClient:
             # Return raw response for inspection
             print(f"Exception decoding from {enc}: {e}")
             return SendMessageResponse(
-                response.content, # better than None?
+                None,
                 response.status_code,
                 response.content,
             )

--- a/claude_api/client.py
+++ b/claude_api/client.py
@@ -616,7 +616,16 @@ class ClaudeAPIClient:
             enc = response.headers["Content-Encoding"]
 
         # Decrypt encoded response
-        dec = self.__decode_response(response.content, enc)
+        try:
+            dec = self.__decode_response(response.content, enc)
+        except Exception as e:
+            # Return raw response for inspection
+            print(f"Exception decoding from {enc}: {e}")
+            return SendMessageResponse(
+                response.content, # better than None?
+                response.status_code,
+                response.content,
+            )
 
         return SendMessageResponse(
             self.__parse_send_message_response(dec),

--- a/claude_api/session.py
+++ b/claude_api/session.py
@@ -38,13 +38,16 @@ class SessionData:
     """
 
 
-def get_session_data(profile: str = "", quiet: bool = False) -> SessionData | None:
+def get_session_data(profile: str = "", quiet: bool = False, organization_index:int=-1) -> SessionData | None:
     """
     Retrieves Claude session data
 
     This function requires a profile with Claude login and geckodriver installed!
 
     The default Firefox profile will be used, if the profile argument was not overwrited.
+
+    Parameter `organization_index` is by default -1
+    (last entry from https://claude.ai/api/organizations)
     """
 
     json_tab_id = 'a[id="rawdata-tab"]'
@@ -81,8 +84,8 @@ def get_session_data(profile: str = "", quiet: bool = False) -> SessionData | No
         if pre.text:
             j = json_loads(pre.text)
             try:
-                if j and len(j) >= 1 and "uuid" in j[0]:
-                    org_id = j[0]["uuid"]
+                if j and len(j) > organization_index and "uuid" in j[organization_index]:
+                    org_id = j[organization_index]["uuid"]
             except KeyError:
                 print(
                     f"\nUnable to retrieve organization_id from profile: {profile}\n"

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(
 
 setup(
     name="unofficial-claude-api",
-    version="0.3.2",
+    version="0.3.3",
     author="st1vms",
     author_email="stefano.maria.salvatore@gmail.com",
     description=__DESCRIPTION,
@@ -35,6 +35,6 @@ setup(
         "selgym",
         "curl_cffi",
         "tzlocal",
-        "brotli",
+        #"brotli",
     ],
 )


### PR DESCRIPTION
# CHANGELOG

- Dropped Brotli decoding.
- Now `get_session_data` always retrieves the latest organization, the `organization_index` parameter was introduced to override the index of the organization to fetch from the array returned in https://claude.ai/api/organizations (Defaults to -1)