### PR TITLE
Add support for Proxy with Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,8 +211,6 @@ __________
 
 ### Proxies
 
-***NOTE ( Only proxies with no user/passwd authentication are supported )***
-
 #### How to set HTTP/S proxies
 
 If you'd like to set an HTTP proxy for all requests, follow this example:

--- a/README.md
+++ b/README.md
@@ -225,6 +225,8 @@ from claude_api.session import SessionData
 http_proxy = HTTPProxy(
     "the.proxy.ip.addr",    # Proxy IP
     8080,                   # Proxy port
+    "username",             # Proxy Username (optional)
+    "password",             # Proxy Password (optional)
     use_ssl=False           # Set to True if proxy uses HTTPS schema
 )
 

--- a/claude_api/client.py
+++ b/claude_api/client.py
@@ -53,15 +53,15 @@ class ClaudeProxy:
     def __post_init__(self):
         if self.proxy_ip is None or self.proxy_port is None:
             raise ValueError("Both proxy_ip and proxy_port must be set")
-        
+
         try:
             port = int(self.proxy_port)
-        except ValueError:
-            raise ValueError("proxy_port must be an integer")
-        
+        except ValueError as e:
+            raise ValueError("proxy_port must be an integer") from e
+
         if not 0 <= port <= 65535:
             raise ValueError(f"Invalid proxy port number: {port}")
-        
+
         self.proxy_port = port
 
         IPv4Address(self.proxy_ip)
@@ -80,8 +80,6 @@ class HTTPProxy(ClaudeProxy):
     `port` -> Proxy port
 
     `use_ssl` -> Boolean flag to indicate if this proxy uses https schema
-
-    NOTE: This proxy must not require user/passwd authentication!
     """
 
     use_ssl: bool = False
@@ -98,8 +96,6 @@ class SOCKSProxy(ClaudeProxy):
 
     `version_num` -> integer flag indicating which SOCKS proxy version to use,
     defaults to 4.
-
-    NOTE: This proxy must not require user/passwd authentication!
     """
 
     version_num: int = 4
@@ -160,7 +156,7 @@ class ClaudeAPIClient:
         self.timezone: str = get_localzone().key
 
     def __get_proxy(self) -> dict[str, str] | None:
-        if self.proxy is None or not isinstance(self.proxy, ClaudeProxy):
+        if self.proxy is None or not issubclass(self.proxy.__class__, ClaudeProxy):
             return None
 
         ip, port = self.proxy.proxy_ip, self.proxy.proxy_port


### PR DESCRIPTION
Username and password are optional arguments

Example usage:
```python
http_proxy = HTTPProxy(
        proxy_ip="ip.addr.net",
        proxy_port=9001,
        proxy_username="user",
        proxy_password="pass",
        use_ssl=False,  # Set to True if proxy uses HTTPS schema
)
...
client = ClaudeAPIClient(session, timeout=240, proxy=http_proxy)
```

Only tested with **http** proxy tho